### PR TITLE
feat: add draw and pan feature 🦀

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.29.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 project("zide")
 set(CMAKE_CXX_STANDARD 17)

--- a/include/app.h
+++ b/include/app.h
@@ -1,5 +1,6 @@
 #include <string>
 #include <vector>
+#include "imgui.h"
 
 enum SelectedTool { SELECTED_PENCIL, SELECTED_ERASER, SELECTED_BUCKET };
 struct ToolbarState {
@@ -34,6 +35,15 @@ struct AppState {
   ToolbarState toolbar_state;
   TimelineState timeline;
   ColorSwatchState color_swatch;
+
+  // editor stuff
+  ImVec2 panOffset = ImVec2(0, 0);
+  ImVec2 lastMousePos = ImVec2(0, 0);
+  bool isPanning = false;
+  float panSpeed = 10.0f;
+  int GRID_SIZE = 512;
+  const int PIXEL_SIZE = 1;
+  std::vector<std::vector<ImVec4>> pixelColors;
 };
 extern AppState app_state;
 
@@ -43,3 +53,5 @@ static void render_toolbar(ToolbarState *toolbar_state);
 static void render_main_menu_bar();
 static void render_timeline();
 static void render_color_swatch();
+static void initialize_grid(int size);
+static void render_grid();

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -10,9 +10,13 @@ ImGuiWindowFlags WINDOWS_FLAG =
     ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoNav |
     ImGuiWindowFlags_NoBringToFrontOnFocus;
 
-void initialize_application() { apply_style(); }
-
 AppState app_state;
+
+void initialize_application() {
+  apply_style();
+  initialize_grid(app_state.GRID_SIZE);
+}
+
 void run_application() {
   render_main_menu_bar();
   if (app_state.is_timeline_visible) {
@@ -24,6 +28,7 @@ void run_application() {
   if (app_state.is_colorswatch_visible) {
     render_color_swatch();
   }
+  render_grid();
 };
 
 static void render_toolbar(ToolbarState *toolbar_state) {
@@ -112,3 +117,133 @@ static void render_color_swatch() {
   ImGui::Begin("Color Swatch", NULL, WINDOWS_FLAG);
   ImGui::End();
 }
+
+static void initialize_grid(int size) {
+  app_state.GRID_SIZE = size;
+  app_state.pixelColors.resize(
+      app_state.GRID_SIZE,
+      std::vector<ImVec4>(app_state.GRID_SIZE, ImVec4(0.0f, 0.0f, 0.0f, 0.0f)));
+}
+
+static void render_grid() {
+  ImDrawList *drawList = ImGui::GetBackgroundDrawList();
+  ImVec2 screenCenter = ImGui::GetIO().DisplaySize;
+  screenCenter.x *= 0.5f;
+  screenCenter.y *= 0.5f;
+  ImVec2 gridTopLeft(
+      screenCenter.x - (app_state.GRID_SIZE * app_state.PIXEL_SIZE / 2) +
+          app_state.panOffset.x,
+      screenCenter.y - (app_state.GRID_SIZE * app_state.PIXEL_SIZE / 2) +
+          app_state.panOffset.y);
+
+  ImVec2 gridBottomRight(
+      screenCenter.x + (app_state.GRID_SIZE * app_state.PIXEL_SIZE / 2) +
+          app_state.panOffset.x,
+      screenCenter.y + (app_state.GRID_SIZE * app_state.PIXEL_SIZE / 2) +
+          app_state.panOffset.y);
+  ImVec2 windowSize = ImGui::GetIO().DisplaySize;
+
+  double gridSize = app_state.GRID_SIZE * app_state.PIXEL_SIZE;
+  double tileSize = gridSize / 8.0;
+
+  for (double y = 0; y < gridSize; y += tileSize) {
+    for (double x = 0; x < gridSize; x += tileSize) {
+      ImVec2 pixelMin(gridTopLeft.x + x, gridTopLeft.y + y);
+      ImVec2 pixelMax(pixelMin.x + tileSize, pixelMin.y + tileSize);
+
+      ImU32 color =
+          ((static_cast<int>(x / tileSize) + static_cast<int>(y / tileSize)) %
+               2 ==
+           0)
+              ? ImColor(200, 200, 200, 255)
+              : ImColor(150, 150, 150, 255);
+
+      drawList->AddRectFilled(pixelMin, pixelMax, color);
+    }
+  }
+
+  int startX =
+      std::max(0, static_cast<int>(-gridTopLeft.x / app_state.PIXEL_SIZE));
+  int startY =
+      std::max(0, static_cast<int>(-gridTopLeft.y / app_state.PIXEL_SIZE));
+  int endX = std::min(
+      app_state.GRID_SIZE,
+      static_cast<int>((windowSize.x - gridTopLeft.x) / app_state.PIXEL_SIZE) +
+          1);
+  int endY = std::min(
+      app_state.GRID_SIZE,
+      static_cast<int>((windowSize.y - gridTopLeft.y) / app_state.PIXEL_SIZE) +
+          1);
+  for (int y = startY; y < endY; y++) {
+    for (int x = startX; x < endX; x++) {
+      ImVec2 pixelMin(gridTopLeft.x + x * app_state.PIXEL_SIZE,
+                      gridTopLeft.y + y * app_state.PIXEL_SIZE);
+      ImVec2 pixelMax(pixelMin.x + app_state.PIXEL_SIZE,
+                      pixelMin.y + app_state.PIXEL_SIZE);
+      drawList->AddRectFilled(pixelMin, pixelMax,
+                              ImColor(app_state.pixelColors[y][x]));
+    }
+  }
+
+  static ImVec2 lastPixel(-1, -1);
+  if (ImGui::IsMouseDown(0)) {
+    ImVec2 mousePos = ImGui::GetMousePos();
+    int x = (mousePos.x - gridTopLeft.x) / app_state.PIXEL_SIZE;
+    int y = (mousePos.y - gridTopLeft.y) / app_state.PIXEL_SIZE;
+    if (x >= 0 && x < app_state.GRID_SIZE && y >= 0 &&
+        y < app_state.GRID_SIZE) {
+if (lastPixel.x != -1 && lastPixel.y != -1) {
+        int pixelDistanceX = abs(x - lastPixel.x);
+        int pixelDistanceY = abs(y - lastPixel.y);
+        int stepX = lastPixel.x < x ? 1 : -1;
+        int stepY = lastPixel.y < y ? 1 : -1;
+        int errorAccumulator = pixelDistanceX - pixelDistanceY;
+        while (true) {
+          if (lastPixel.x >= 0 && lastPixel.x < app_state.GRID_SIZE &&
+              lastPixel.y >= 0 && lastPixel.y < app_state.GRID_SIZE) {
+            app_state.pixelColors[lastPixel.y][lastPixel.x] =
+                ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
+            ImVec2 pixelMin(gridTopLeft.x + lastPixel.x * app_state.PIXEL_SIZE,
+                            gridTopLeft.y + lastPixel.y * app_state.PIXEL_SIZE);
+            ImVec2 pixelMax(pixelMin.x + app_state.PIXEL_SIZE,
+                            pixelMin.y + app_state.PIXEL_SIZE);
+            drawList->AddRectFilled(
+                pixelMin, pixelMax,
+                ImColor(app_state.pixelColors[lastPixel.y][lastPixel.x]));
+          }
+          if (lastPixel.x == x && lastPixel.y == y)
+            break;
+
+          int errorDouble = 2 * errorAccumulator;
+          if (errorDouble > -pixelDistanceY) {
+            errorAccumulator -= pixelDistanceY;
+            lastPixel.x += stepX;
+          }
+          if (errorDouble < pixelDistanceX) {
+            errorAccumulator += pixelDistanceX;
+            lastPixel.y += stepY;
+          }
+        }
+      }
+      lastPixel = ImVec2(x, y);
+    } else
+      lastPixel = ImVec2(-1, -1);
+  } else
+    lastPixel = ImVec2(-1, -1);
+
+  ImGuiIO &io = ImGui::GetIO();
+  if (ImGui::IsMouseDragging(ImGuiMouseButton_Middle)) {
+    if (!app_state.isPanning) {
+      app_state.isPanning = true;
+      app_state.lastMousePos = io.MousePos;
+    }
+    ImVec2 mouseDelta = ImVec2(io.MousePos.x - app_state.lastMousePos.x,
+                               io.MousePos.y - app_state.lastMousePos.y);
+    app_state.panOffset.x += mouseDelta.x;
+    app_state.panOffset.y += mouseDelta.y;
+    app_state.lastMousePos = io.MousePos;
+  } else {
+    app_state.isPanning = false;
+  }
+}
+


### PR DESCRIPTION
This PR introduces several new features to enhance the drawing canvas functionality. The key additions include an infinite scratch area, the ability to pan around the canvas, and basic drawing capabilities. Mouse and keyboard events have been bound to enable these features effectively.

# Changes:
#### Infinite Scratch Area:
Expanded the canvas area to allow for infinite scrolling, ensuring users can draw without size constraints.

#### Panning Around Canvas:
Implemented the ability to pan around the canvas using mouse events, enabling easy navigation across the expanded scratch area.

#### Drawing Functionality:
Added basic drawing capabilities, allowing users to draw freely on the canvas.

#### Mouse and Keyboard Event Binding:
Bound mouse and keyboard events to handle interactions such as panning, drawing, and potentially future features.

![draw_and_pan_feature](https://github.com/user-attachments/assets/2d9aec64-095a-4792-bbd3-dcd78575d4e0)

